### PR TITLE
bump: v0.10.1 - fix libpython linking for abi3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to PyOZ will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - 2026-02-06
+
+### Fixed
+- **libpython linking broke abi3 portability** - The 0.10.0 wheels linked against `libpython3.12.so` (the CI's Python version), causing `ImportError` on any other Python version. On Linux/macOS, the extension no longer links against libpython at all (symbols come from the interpreter at runtime). On Windows, it links against `python3.dll` (the version-agnostic stable ABI DLL) instead of `python3XX.dll`.
+
 ## [0.10.0] - 2026-02-06
 
 ### Added

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .PyOZ,
-    .version = "0.10.0",
+    .version = "0.10.1",
     .fingerprint = 0x4d3668413e69d99e,
     .dependencies = .{},
     .paths = .{

--- a/pypi/build.zig.zon
+++ b/pypi/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .pyoz,
-    .version = "0.10.0",
+    .version = "0.10.1",
     .fingerprint = 0x43eec3150282fd1f,
     .dependencies = .{
         .PyOZ = .{

--- a/pypi/pyproject.toml
+++ b/pypi/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyoz"
-version = "0.10.0"
+version = "0.10.1"
 description = "Python extension modules in Zig, made easy"
 readme = "README.md"
 license = "MIT"

--- a/src/version.zig
+++ b/src/version.zig
@@ -3,7 +3,7 @@
 
 pub const major: u8 = 0;
 pub const minor: u8 = 10;
-pub const patch: u8 = 0;
+pub const patch: u8 = 1;
 
 /// Pre-release identifier (e.g., "alpha", "beta", "rc1", or null for release)
 pub const pre_release: ?[]const u8 = null;


### PR DESCRIPTION
Version bump to 0.10.1. The 0.10.0 wheels were broken due to hardcoded libpython3.12 linking.