### PR TITLE
fix: optional null returns from methods now return None instead of raising RuntimeError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to PyOZ will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.4] - 2026-02-09
+
+### Fixed
+- **Optional return types from methods raised `RuntimeError` instead of returning `None`** - When a Zig method returned `?T` (optional) and the value was `null`, PyOZ raised `RuntimeError: method returned null` instead of returning Python `None`. This affected instance methods, static methods, class methods, `__call__`, `__get__`, `__iter__`, `__repr__`/`__str__`, and number protocol operations. The method dispatch now correctly returns `None` for null optionals (matching the behavior of standalone functions and the conversion system). Improved error messages for `__len__` and `__new__` optional null returns, which are legitimately errors since Python requires concrete values from those slots.
+
 ## [0.10.3] - 2026-02-07
 
 ### Added

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .PyOZ,
-    .version = "0.10.3",
+    .version = "0.10.4",
     .fingerprint = 0x4d3668413e69d99e,
     .dependencies = .{},
     .paths = .{

--- a/pypi/build.zig.zon
+++ b/pypi/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .pyoz,
-    .version = "0.10.3",
+    .version = "0.10.4",
     .fingerprint = 0x43eec3150282fd1f,
     .dependencies = .{
         .PyOZ = .{

--- a/pypi/pyproject.toml
+++ b/pypi/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyoz"
-version = "0.10.3"
+version = "0.10.4"
 description = "Python extension modules in Zig, made easy"
 readme = "README.md"
 license = "MIT"

--- a/src/lib/class/callable.zig
+++ b/src/lib/class/callable.zig
@@ -97,10 +97,8 @@ pub fn CallableProtocol(comptime _: [*:0]const u8, comptime T: type, comptime Pa
                 if (result) |value| {
                     return Conv.toPy(@TypeOf(value), value);
                 } else {
-                    if (py.PyErr_Occurred() == null) {
-                        py.PyErr_SetString(py.PyExc_RuntimeError(), "__call__ returned null");
-                    }
-                    return null;
+                    if (py.PyErr_Occurred() != null) return null;
+                    return py.Py_RETURN_NONE();
                 }
             } else if (ReturnType == void) {
                 return py.Py_RETURN_NONE();

--- a/src/lib/class/descriptor.zig
+++ b/src/lib/class/descriptor.zig
@@ -30,10 +30,8 @@ pub fn DescriptorProtocol(comptime _: [*:0]const u8, comptime T: type, comptime 
                 if (result) |value| {
                     return Conv.toPy(@TypeOf(value), value);
                 } else {
-                    if (py.PyErr_Occurred() == null) {
-                        py.PyErr_SetString(py.PyExc_AttributeError(), "__get__ returned null");
-                    }
-                    return null;
+                    if (py.PyErr_Occurred() != null) return null;
+                    return py.Py_RETURN_NONE();
                 }
             } else {
                 return Conv.toPy(RetType, result);

--- a/src/lib/class/iterator.zig
+++ b/src/lib/class/iterator.zig
@@ -46,10 +46,8 @@ pub fn IteratorProtocol(comptime _: [*:0]const u8, comptime T: type, comptime Pa
                         return Conv.toPy(ResultType, result);
                     }
                 } else {
-                    if (py.PyErr_Occurred() == null) {
-                        py.PyErr_SetString(py.PyExc_RuntimeError(), "__iter__ returned null");
-                    }
-                    return null;
+                    if (py.PyErr_Occurred() != null) return null;
+                    return py.Py_RETURN_NONE();
                 }
             } else {
                 const result = T.__iter__(self.getData());

--- a/src/lib/class/lifecycle.zig
+++ b/src/lib/class/lifecycle.zig
@@ -187,7 +187,7 @@ pub fn LifecycleBuilder(
                     return 0;
                 } else {
                     if (py.PyErr_Occurred() == null) {
-                        py.PyErr_SetString(py.PyExc_TypeError(), "__new__ returned null");
+                        py.PyErr_SetString(py.PyExc_TypeError(), "__new__ returned null, expected an instance");
                     }
                     return -1;
                 }

--- a/src/lib/class/mapping.zig
+++ b/src/lib/class/mapping.zig
@@ -50,7 +50,7 @@ pub fn MappingProtocol(comptime _: [*:0]const u8, comptime T: type, comptime Par
                     return @intCast(result);
                 } else {
                     if (py.PyErr_Occurred() == null) {
-                        py.PyErr_SetString(py.PyExc_RuntimeError(), "__len__ returned null");
+                        py.PyErr_SetString(py.PyExc_TypeError(), "__len__ returned null, expected an integer");
                     }
                     return -1;
                 }

--- a/src/lib/class/methods.zig
+++ b/src/lib/class/methods.zig
@@ -404,10 +404,8 @@ pub fn MethodBuilder(comptime _: [*:0]const u8, comptime T: type, comptime PyWra
                         if (result) |value| {
                             return Conv.toPy(@TypeOf(value), value);
                         } else {
-                            if (py.PyErr_Occurred() == null) {
-                                py.PyErr_SetString(py.PyExc_RuntimeError(), "method returned null");
-                            }
-                            return null;
+                            if (py.PyErr_Occurred() != null) return null;
+                            return py.Py_RETURN_NONE();
                         }
                     } else if (ReturnType == void) {
                         return py.Py_RETURN_NONE();
@@ -511,10 +509,8 @@ pub fn MethodBuilder(comptime _: [*:0]const u8, comptime T: type, comptime PyWra
                         if (result) |value| {
                             return Conv.toPy(@TypeOf(value), value);
                         } else {
-                            if (py.PyErr_Occurred() == null) {
-                                py.PyErr_SetString(py.PyExc_RuntimeError(), "method returned null");
-                            }
-                            return null;
+                            if (py.PyErr_Occurred() != null) return null;
+                            return py.Py_RETURN_NONE();
                         }
                     } else if (ReturnType == void) {
                         return py.Py_RETURN_NONE();
@@ -621,10 +617,8 @@ pub fn MethodBuilder(comptime _: [*:0]const u8, comptime T: type, comptime PyWra
                         if (result) |value| {
                             return Conv.toPy(@TypeOf(value), value);
                         } else {
-                            if (py.PyErr_Occurred() == null) {
-                                py.PyErr_SetString(py.PyExc_RuntimeError(), "method returned null");
-                            }
-                            return null;
+                            if (py.PyErr_Occurred() != null) return null;
+                            return py.Py_RETURN_NONE();
                         }
                     } else if (ReturnType == void) {
                         return py.Py_RETURN_NONE();

--- a/src/lib/class/number.zig
+++ b/src/lib/class/number.zig
@@ -108,10 +108,8 @@ pub fn NumberProtocol(comptime _: [*:0]const u8, comptime T: type, comptime Pare
                 if (result) |value| {
                     return Conv.toPy(@TypeOf(value), value);
                 } else {
-                    if (py.PyErr_Occurred() == null) {
-                        py.PyErr_SetString(default_exc, "operation returned null");
-                    }
-                    return null;
+                    if (py.PyErr_Occurred() != null) return null;
+                    return py.Py_RETURN_NONE();
                 }
             } else {
                 return Conv.toPy(RetType, result);

--- a/src/lib/class/repr.zig
+++ b/src/lib/class/repr.zig
@@ -178,10 +178,8 @@ pub fn ReprProtocol(comptime name: [*:0]const u8, comptime T: type, comptime Par
                 if (result) |value| {
                     return Conv.toPy(@TypeOf(value), value);
                 } else {
-                    if (py.PyErr_Occurred() == null) {
-                        py.PyErr_SetString(py.PyExc_RuntimeError(), "repr/str returned null");
-                    }
-                    return null;
+                    if (py.PyErr_Occurred() != null) return null;
+                    return py.Py_RETURN_NONE();
                 }
             } else {
                 return Conv.toPy(RetType, result);

--- a/src/lib/class/sequence.zig
+++ b/src/lib/class/sequence.zig
@@ -51,7 +51,7 @@ pub fn SequenceProtocol(comptime _: [*:0]const u8, comptime T: type, comptime Pa
                     return @intCast(result);
                 } else {
                     if (py.PyErr_Occurred() == null) {
-                        py.PyErr_SetString(py.PyExc_RuntimeError(), "__len__ returned null");
+                        py.PyErr_SetString(py.PyExc_TypeError(), "__len__ returned null, expected an integer");
                     }
                     return -1;
                 }

--- a/src/version.zig
+++ b/src/version.zig
@@ -3,7 +3,7 @@
 
 pub const major: u8 = 0;
 pub const minor: u8 = 10;
-pub const patch: u8 = 3;
+pub const patch: u8 = 4;
 
 /// Pre-release identifier (e.g., "alpha", "beta", "rc1", or null for release)
 pub const pre_release: ?[]const u8 = null;


### PR DESCRIPTION
When a Zig method returned an optional type (?T) and the value was null, PyOZ raised RuntimeError: method returned null instead of returning Python None.

This affected instance methods, static methods, class methods, __call__, __get__, __iter__, __repr__/__str__, and number protocol operations.

The method dispatch now correctly returns None for null optionals, matching the behavior of standalone functions and the conversion system.

Also improved error messages for __len__ and __new__ optional null returns, which are legitimately errors since Python requires concrete values from those slots.

Version bumped to 0.10.4.