### PR TITLE
feat: add pyoz.Ref(T) for strong cross-object Python references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to PyOZ will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.5] - 2026-02-09
+
+### Added
+- **`pyoz.Ref(T)` -- strong Python object references** - New generic type that allows one PyOZ-managed Zig struct to hold a strong reference to another Python object, preventing use-after-free when the referenced object is garbage collected. `Ref(T)` wraps a `?*PyObject` with automatic `Py_IncRef` on `set()` and `Py_DecRef` on `clear()` and object deallocation. Ref fields are automatically excluded from Python properties, `__init__` parameters, stub generation, and auto-doc signatures. Freelist-safe: references are released in `tp_dealloc` before freelist push, and `std.mem.zeroes` on pop ensures no double-free.
+- **`Module.selfObject(T, ptr)` helper** - Recovers the wrapping `*PyObject` from a `*const T` data pointer using compile-time offset math. Used to obtain the PyObject needed for `Ref(T).set()` from within methods that receive `self: *const T`.
+
 ## [0.10.4] - 2026-02-09
 
 ### Fixed

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .PyOZ,
-    .version = "0.10.4",
+    .version = "0.10.5",
     .fingerprint = 0x4d3668413e69d99e,
     .dependencies = .{},
     .paths = .{

--- a/pypi/build.zig.zon
+++ b/pypi/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .pyoz,
-    .version = "0.10.4",
+    .version = "0.10.5",
     .fingerprint = 0x43eec3150282fd1f,
     .dependencies = .{
         .PyOZ = .{

--- a/pypi/pyproject.toml
+++ b/pypi/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyoz"
-version = "0.10.4"
+version = "0.10.5"
 description = "Python extension modules in Zig, made easy"
 readme = "README.md"
 license = "MIT"

--- a/src/lib/ref.zig
+++ b/src/lib/ref.zig
@@ -1,0 +1,94 @@
+//! Strong Python object references for cross-object lifetime management.
+//!
+//! `Ref(T)` allows one PyOZ-managed struct to hold a strong reference to another,
+//! preventing the referenced object from being garbage collected while the reference exists.
+//!
+//! Usage:
+//! ```zig
+//! const Node = struct {
+//!     _parser: pyoz.Ref(GrammarParser),
+//!     _index: u32,
+//!
+//!     pub fn text(self: *const Node) []const u8 {
+//!         const parser = self._parser.get().?;
+//!         // ... safely use parser data ...
+//!     }
+//! };
+//! ```
+
+const py = @import("python.zig");
+const class_mod = @import("class.zig");
+
+/// A strong reference to a Python-managed Zig object of type `T`.
+///
+/// Stores a `?*PyObject` internally and manages INCREF/DECREF automatically.
+/// PyOZ's class machinery calls `clear()` on deallocation (including freelist eviction).
+///
+/// Default value is null (no reference held). Fields should be declared as:
+///     _parser: pyoz.Ref(GrammarParser) = .{},
+/// or simply:
+///     _parser: pyoz.Ref(GrammarParser),
+/// (zero-init in py_new handles the default)
+pub fn Ref(comptime T: type) type {
+    return extern struct {
+        const Self = @This();
+
+        /// Comptime marker for detection by lifecycle/properties/stubs.
+        pub const __pyoz_ref__ = true;
+
+        /// The referenced Zig type.
+        pub const RefType = T;
+
+        /// The underlying Python object pointer (null = no reference held).
+        _py_obj: ?*py.PyObject = null,
+
+        /// Store a reference to a Python object. INCREFs the new object
+        /// and DECREFs any previously held reference.
+        pub fn set(self: *Self, obj: *py.PyObject) void {
+            const old = self._py_obj;
+            py.Py_IncRef(obj);
+            self._py_obj = obj;
+            if (old) |o| py.Py_DecRef(o);
+        }
+
+        /// Get an immutable pointer to the referenced Zig data, or null if no reference is held.
+        pub fn get(self: *const Self, comptime class_infos: []const class_mod.ClassInfo) ?*const T {
+            const obj = self._py_obj orelse return null;
+            const Wrapper = class_mod.getWrapperWithName(comptime getClassName(class_infos), T, class_infos);
+            return Wrapper.unwrapConst(obj);
+        }
+
+        /// Get a mutable pointer to the referenced Zig data, or null if no reference is held.
+        pub fn getMut(self: *Self, comptime class_infos: []const class_mod.ClassInfo) ?*T {
+            const obj = self._py_obj orelse return null;
+            const Wrapper = class_mod.getWrapperWithName(comptime getClassName(class_infos), T, class_infos);
+            return Wrapper.unwrap(obj);
+        }
+
+        /// Get the raw PyObject pointer (borrowed reference).
+        pub fn object(self: *const Self) ?*py.PyObject {
+            return self._py_obj;
+        }
+
+        /// Release the held reference (DECREF) and set to null.
+        pub fn clear(self: *Self) void {
+            if (self._py_obj) |obj| {
+                self._py_obj = null;
+                py.Py_DecRef(obj);
+            }
+        }
+
+        /// Look up the class name for T in class_infos at comptime.
+        fn getClassName(comptime class_infos: []const class_mod.ClassInfo) [*:0]const u8 {
+            inline for (class_infos) |info| {
+                if (info.zig_type == T) return info.name;
+            }
+            @compileError("Ref(" ++ @typeName(T) ++ "): type is not a registered class");
+        }
+    };
+}
+
+/// Check at comptime whether a type is a `Ref(T)`.
+pub fn isRefType(comptime FieldType: type) bool {
+    return @typeInfo(FieldType) == .@"struct" and @hasDecl(FieldType, "__pyoz_ref__");
+}

--- a/src/version.zig
+++ b/src/version.zig
@@ -3,7 +3,7 @@
 
 pub const major: u8 = 0;
 pub const minor: u8 = 10;
-pub const patch: u8 = 4;
+pub const patch: u8 = 5;
 
 /// Pre-release identifier (e.g., "alpha", "beta", "rc1", or null for release)
 pub const pre_release: ?[]const u8 = null;


### PR DESCRIPTION
Add Ref(T) -- Strong Python Object References

When a Zig struct (e.g. Node) holds raw pointers into data owned by another Python object (e.g. GrammarParser), Python's GC can free the parser while Nodes still reference its memory, causing use-after-free. Ref(T) solves this by wrapping a ?*PyObject with automatic Py_IncRef on set() and Py_DecRef on clear()/deallocation.

Changes

- New src/lib/ref.zig with Ref(T) generic type providing set(), get(), getMut(), clear(), and object() methods
- Auto-DECREF all Ref fields in py_dealloc before freelist push, ensuring no leaks or double-frees
- Skip Ref fields from Python properties, __init__ parameters, stub generation, and auto-doc signatures
- Add Module.selfObject(T, ptr) helper to recover the wrapping PyObject from a *const T data pointer
- Add objectFromData() pointer math to the class wrapper
- Comprehensive tests covering basic usage, lifetime management, refcount correctness, freelist behavior, init exclusion, and property exclusion

Version bumped to 0.10.5