### PR TITLE
fix: Windows build support and package mode improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to PyOZ will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.2] - 2026-02-10
+
+### Fixed
+- **Windows build support** - Fixed 77 `lld-link: undefined symbol` errors when building PyOZ projects on Windows. The generated `build.zig` template now accepts `-Dpython-lib-dir` and `-Dpython-lib-name` options, and `pyoz build` passes them automatically on Windows to link against `python3.lib` (stable ABI). Windows requires all symbols resolved at link time, unlike Linux/macOS which resolve Python symbols at runtime.
+- **Windows output path** - Fixed `FileNotFound` error during wheel creation on Windows. Zig places DLLs (`.pyd`) in `zig-out/bin/` on Windows, not `zig-out/lib/`. The builder, test runner, and benchmark runner now use the correct output directory per platform.
+- **Package mode test/bench imports** - In package layout (module name starts with `_`), the generated test and benchmark scripts now also `import ravn` (the package name) in addition to `import _ravn`, so users can write `assert ravn.add(2, 3) == 5` in their tests. The test/bench runners also detect package mode, copy the `.pyd`/`.so` into the package directory, and add the project root to `PYTHONPATH`.
+- **ASCII tree output for `pyoz init`** - Replaced UTF-8 box-drawing characters with ASCII in the project structure output, fixing garbled display on Windows PowerShell.
+
 ## [0.11.1] - 2026-02-10
 
 ### Added

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .PyOZ,
-    .version = "0.11.1",
+    .version = "0.11.2",
     .fingerprint = 0x4d3668413e69d99e,
     .dependencies = .{},
     .paths = .{

--- a/pypi/build.zig.zon
+++ b/pypi/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .pyoz,
-    .version = "0.11.1",
+    .version = "0.11.2",
     .fingerprint = 0x43eec3150282fd1f,
     .dependencies = .{
         .PyOZ = .{

--- a/pypi/pyproject.toml
+++ b/pypi/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyoz"
-version = "0.11.1"
+version = "0.11.2"
 description = "Python extension modules in Zig, made easy"
 readme = "README.md"
 license = "MIT"

--- a/pypi/setup.cfg
+++ b/pypi/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pyoz
-version = 0.11.1
+version = 0.11.2
 
 [options]
 packages = pyoz

--- a/src/cli/project.zig
+++ b/src/cli/project.zig
@@ -110,15 +110,15 @@ pub fn create(allocator: std.mem.Allocator, name_opt: ?[]const u8, in_current_di
             \\
             \\Project structure:
             \\  {s}/
-            \\  ├── pyproject.toml    # Project configuration
-            \\  ├── build.zig         # Zig build script
-            \\  ├── build.zig.zon     # Zig dependencies
-            \\  ├── README.md
-            \\  ├── .gitignore
-            \\  ├── src/
-            \\  │   └── lib.zig       # Your Zig extension code
-            \\  └── {s}/
-            \\      └── __init__.py   # Python package entry point
+            \\  +-- pyproject.toml    # Project configuration
+            \\  +-- build.zig         # Zig build script
+            \\  +-- build.zig.zon     # Zig dependencies
+            \\  +-- README.md
+            \\  +-- .gitignore
+            \\  +-- src/
+            \\  |   +-- lib.zig       # Your Zig extension code
+            \\  +-- {s}/
+            \\      +-- __init__.py   # Python package entry point
             \\
             \\Next steps:
             \\
@@ -130,13 +130,13 @@ pub fn create(allocator: std.mem.Allocator, name_opt: ?[]const u8, in_current_di
             \\
             \\Project structure:
             \\  {s}/
-            \\  ├── pyproject.toml    # Project configuration
-            \\  ├── build.zig         # Zig build script
-            \\  ├── build.zig.zon     # Zig dependencies
-            \\  ├── README.md
-            \\  ├── .gitignore
-            \\  └── src/
-            \\      └── lib.zig       # Your module code
+            \\  +-- pyproject.toml    # Project configuration
+            \\  +-- build.zig         # Zig build script
+            \\  +-- build.zig.zon     # Zig dependencies
+            \\  +-- README.md
+            \\  +-- .gitignore
+            \\  +-- src/
+            \\      +-- lib.zig       # Your module code
             \\
             \\Next steps:
             \\
@@ -571,6 +571,16 @@ const build_zig_template =
     \\    // Link libc (required for Python C API)
     \\    lib.linkLibC();
     \\
+    \\    // On Windows, link against the Python stable ABI library (python3.lib).
+    \\    // These options are passed automatically by `pyoz build`.
+    \\    // For manual `zig build` on Windows, pass: -Dpython-lib-dir=<path> -Dpython-lib-name=python3
+    \\    if (b.option([]const u8, "python-lib-dir", "Python library directory")) |lib_dir| {
+    \\        lib.addLibraryPath(.{ .cwd_relative = lib_dir });
+    \\    }
+    \\    if (b.option([]const u8, "python-lib-name", "Python library name")) |lib_name| {
+    \\        lib.linkSystemLibrary(lib_name);
+    \\    }
+    \\
     \\    // Determine extension based on target OS (.pyd for Windows, .so otherwise)
     \\    const ext = if (builtin.os.tag == .windows) ".pyd" else ".so";
     \\
@@ -627,6 +637,16 @@ const build_zig_package_template =
     \\
     \\    // Link libc (required for Python C API)
     \\    lib.linkLibC();
+    \\
+    \\    // On Windows, link against the Python stable ABI library (python3.lib).
+    \\    // These options are passed automatically by `pyoz build`.
+    \\    // For manual `zig build` on Windows, pass: -Dpython-lib-dir=<path> -Dpython-lib-name=python3
+    \\    if (b.option([]const u8, "python-lib-dir", "Python library directory")) |lib_dir| {
+    \\        lib.addLibraryPath(.{ .cwd_relative = lib_dir });
+    \\    }
+    \\    if (b.option([]const u8, "python-lib-name", "Python library name")) |lib_name| {
+    \\        lib.linkSystemLibrary(lib_name);
+    \\    }
     \\
     \\    // Determine extension based on target OS (.pyd for Windows, .so otherwise)
     \\    const ext = if (builtin.os.tag == .windows) ".pyd" else ".so";

--- a/src/lib/root.zig
+++ b/src/lib/root.zig
@@ -663,9 +663,17 @@ fn generateTestContent(comptime config: anytype) []const u8 {
             break :blk config.name[0..len];
         };
 
+        // In package mode (module name starts with '_'), also import the package name
+        // so users can write `assert ravn.add(2, 3) == 5` instead of `assert _ravn.add(2, 3) == 5`
+        const pkg_import: []const u8 = if (mod_name.len > 1 and mod_name[0] == '_')
+            "import " ++ mod_name[1..] ++ "\n"
+        else
+            "";
+
         var result: []const u8 =
             "import unittest\n" ++
             "import " ++ mod_name ++ "\n" ++
+            pkg_import ++
             "\n" ++
             "\n" ++
             "class Test" ++ capitalizeFirst(mod_name) ++ "(unittest.TestCase):\n";
@@ -706,9 +714,15 @@ fn generateBenchContent(comptime config: anytype) []const u8 {
             break :blk config.name[0..len];
         };
 
+        const bench_pkg_import: []const u8 = if (mod_name.len > 1 and mod_name[0] == '_')
+            "import " ++ mod_name[1..] ++ "\n"
+        else
+            "";
+
         var result: []const u8 =
             "import timeit\n" ++
             "import " ++ mod_name ++ "\n" ++
+            bench_pkg_import ++
             "\n" ++
             "\n" ++
             "def run_benchmarks():\n" ++

--- a/src/version.zig
+++ b/src/version.zig
@@ -3,7 +3,7 @@
 
 pub const major: u8 = 0;
 pub const minor: u8 = 11;
-pub const patch: u8 = 1;
+pub const patch: u8 = 2;
 
 /// Pre-release identifier (e.g., "alpha", "beta", "rc1", or null for release)
 pub const pre_release: ?[]const u8 = null;


### PR DESCRIPTION
Fixes Windows build, output paths, and package mode test/bench imports.

Changes:

- Pass -Dpython-lib-dir and -Dpython-lib-name=python3 to zig build on Windows to resolve 77 lld-link undefined symbol errors (Windows requires all symbols at link time, unlike Unix which resolves at runtime)
- Use zig-out/bin/ for .pyd files on Windows (Zig places DLLs in bin/, not lib/)
- Detect package mode in test/bench runners: copy .pyd into package directory and add project root to PYTHONPATH so "import ravn" works
- Generate "import ravn" in addition to "import _ravn" in test/bench scripts when module name starts with underscore (package layout)
- Replace UTF-8 box-drawing chars with ASCII in pyoz init output for Windows

Version bumped to 0.11.2.