### PR TITLE
fix: deduplicate test/bench logic for pip package Windows support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to PyOZ will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.3] - 2026-02-10
+
+### Fixed
+- **pip-installed pyoz test/bench on Windows** - Deduplicated test/bench runner logic in the pip package (`pypi/src/lib.zig`) by delegating to `commands.runTests`/`commands.runBench` instead of maintaining a separate copy. The previous duplicate code had hardcoded `zig-out/lib/` paths and no package mode support, causing test failures on Windows.
+
 ## [0.11.2] - 2026-02-10
 
 ### Fixed

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .PyOZ,
-    .version = "0.11.2",
+    .version = "0.11.3",
     .fingerprint = 0x4d3668413e69d99e,
     .dependencies = .{},
     .paths = .{

--- a/pypi/build.zig.zon
+++ b/pypi/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .pyoz,
-    .version = "0.11.2",
+    .version = "0.11.3",
     .fingerprint = 0x43eec3150282fd1f,
     .dependencies = .{
         .PyOZ = .{

--- a/pypi/pyproject.toml
+++ b/pypi/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyoz"
-version = "0.11.2"
+version = "0.11.3"
 description = "Python extension modules in Zig, made easy"
 readme = "README.md"
 license = "MIT"

--- a/pypi/setup.cfg
+++ b/pypi/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pyoz
-version = 0.11.2
+version = 0.11.3
 
 [options]
 packages = pyoz

--- a/src/version.zig
+++ b/src/version.zig
@@ -3,7 +3,7 @@
 
 pub const major: u8 = 0;
 pub const minor: u8 = 11;
-pub const patch: u8 = 2;
+pub const patch: u8 = 3;
 
 /// Pre-release identifier (e.g., "alpha", "beta", "rc1", or null for release)
 pub const pre_release: ?[]const u8 = null;


### PR DESCRIPTION
Delegates test/bench runner logic in pypi/src/lib.zig to commands.runTests/runBench instead of maintaining a duplicate copy. The previous duplicate had hardcoded zig-out/lib/ paths and no package mode detection, causing pyoz test to fail on Windows when installed via pip.

Bump version to 0.11.3.