### PR TITLE
Classes support `pyoz.Args()`

### DIFF
--- a/docs/guide/classes.md
+++ b/docs/guide/classes.md
@@ -33,7 +33,7 @@ const MyClass = struct {
     // Public fields - exposed to Python
     name: []const u8,
     value: i64,
-    
+
     // Private fields - NOT exposed to Python
     _internal_counter: i64,
     _cache: ?SomeType,
@@ -58,7 +58,7 @@ This is useful for:
 const Counter = struct {
     count: i64,           // Public: users can read/write this
     _step: i64,           // Private: internal implementation detail
-    
+
     pub fn increment(self: *Counter) void {
         self.count += self._step;  // Methods can access private fields
     }
@@ -112,6 +112,30 @@ PyOZ auto-detects method types based on the first parameter:
 | Anything else | Static method | `Class.method()` |
 
 Use `*const Self` for methods that don't modify the instance.
+
+### Keyword Arguments on Methods
+
+Methods can use `pyoz.Args(T)` for keyword arguments, just like module-level functions:
+
+```zig
+const Point = struct {
+    x: f64,
+    y: f64,
+
+    pub fn translate(self: *Point, args: pyoz.Args(struct {
+        dx: f64 = 0,
+        dy: f64 = 0,
+    })) void {
+        self.x += args.value.dx;
+        self.y += args.value.dy;
+    }
+};
+```
+
+Python: `p.translate(dx=3.0)`, `p.translate(1.0, 2.0)`, or `p.translate()`
+
+Struct fields with defaults become optional keyword arguments,
+same as [module-level keyword functions](functions.md#keyword-arguments-pyozkwfunc).
 
 ## Docstrings
 

--- a/examples/example_module.zig
+++ b/examples/example_module.zig
@@ -1169,6 +1169,15 @@ const Point = struct {
         return self.x * other_x + self.y * other_y;
     }
 
+    /// Translate the point by dx and dy (keyword arguments)
+    pub fn translate(self: *Point, args: pyoz.Args(struct {
+        dx: f64 = 0,
+        dy: f64 = 0,
+    })) void {
+        self.x += args.value.dx;
+        self.y += args.value.dy;
+    }
+
     /// Static method: create origin point (no self!)
     pub fn origin() Point {
         return .{ .x = 0.0, .y = 0.0 };

--- a/src/lib/class/methods.zig
+++ b/src/lib/class/methods.zig
@@ -14,6 +14,7 @@ const class_mod = @import("mod.zig");
 const ClassInfo = class_mod.ClassInfo;
 const source_parser = @import("../source_parser.zig");
 const errors_mod = @import("../errors.zig");
+const wrappers_mod = @import("../wrappers.zig");
 
 /// Build method wrappers for a given type
 pub fn MethodBuilder(comptime class_name: [*:0]const u8, comptime T: type, comptime PyWrapper: type, comptime class_infos: []const ClassInfo, comptime slot_dunders: []const []const u8) type {
@@ -181,6 +182,18 @@ pub fn MethodBuilder(comptime class_name: [*:0]const u8, comptime T: type, compt
             return FirstParam == type;
         }
 
+        /// Check if an instance method uses pyoz.Args(T) for keyword arguments.
+        fn isMethodNamedKwargs(comptime method_name: []const u8) bool {
+            const method = @field(T, method_name);
+            const fn_info = @typeInfo(@TypeOf(method)).@"fn";
+            if (fn_info.params.len < 2) return false;
+
+            const P = fn_info.params[1].type orelse return false;
+            if (@typeInfo(P) != .@"struct") return false;
+
+            return @hasDecl(P, "is_pyoz_args");
+        }
+
         // ====================================================================
         // Docstring helpers
         // ====================================================================
@@ -232,15 +245,23 @@ pub fn MethodBuilder(comptime class_name: [*:0]const u8, comptime T: type, compt
             // Add instance methods
             for (decls) |decl| {
                 if (isInstanceMethod(decl.name)) {
+                    const is_kwargs = isMethodNamedKwargs(decl.name);
+
                     m[idx] = .{
                         .ml_name = @ptrCast(decl.name.ptr),
-                        .ml_meth = @ptrCast(generateMethodWrapper(decl.name)),
-                        .ml_flags = py.METH_VARARGS,
+                        .ml_meth = if (is_kwargs)
+                            @ptrCast(generateMethodWrapperWithKeywords(decl.name))
+                        else
+                            @ptrCast(generateMethodWrapper(decl.name)),
+                        .ml_flags = if (is_kwargs)
+                            py.METH_VARARGS | py.METH_KEYWORDS
+                        else
+                            py.METH_VARARGS,
                         .ml_doc = stubs_mod.buildMlDoc(
                             decl.name,
                             @TypeOf(@field(T, decl.name)),
                             .instance_method,
-                            .positional,
+                            if (is_kwargs) .args_struct else .positional,
                             getMethodDoc(decl.name),
                             getMethodParams(decl.name),
                         ),
@@ -484,6 +505,94 @@ pub fn MethodBuilder(comptime class_name: [*:0]const u8, comptime T: type, compt
                             return Conv.toPy(@TypeOf(value), value);
                         } else {
                             if (py.PyErr_Occurred() != null) return null;
+                            return py.Py_RETURN_NONE();
+                        }
+                    } else if (ReturnType == void) {
+                        return py.Py_RETURN_NONE();
+                    } else {
+                        return Conv.toPy(ReturnType, result);
+                    }
+                }
+            }.wrapper;
+        }
+
+        // ====================================================================
+        // Instance method wrapper generation (keyword arguments via Args(T))
+        // ====================================================================
+
+        fn generateMethodWrapperWithKeywords(comptime method_name: []const u8) *const fn (
+            ?*py.PyObject,
+            ?*py.PyObject,
+            ?*py.PyObject,
+        ) callconv(.c) ?*py.PyObject {
+            const method = @field(T, method_name);
+            const fn_info = @typeInfo(@TypeOf(method)).@"fn";
+            const params = fn_info.params;
+            const RawReturnType = fn_info.return_type orelse void;
+            const ReturnType = unwrapSignature(RawReturnType);
+
+            const ArgsWrapperType = params[1].type.?;
+            const ArgsStructType = ArgsWrapperType.ArgsStruct;
+
+            return struct {
+                fn wrapper(
+                    self_obj: ?*py.PyObject,
+                    args: ?*py.PyObject,
+                    kwargs: ?*py.PyObject,
+                ) callconv(.c) ?*py.PyObject {
+                    const self: *PyWrapper = @ptrCast(@alignCast(self_obj orelse return null));
+
+                    const result_args = wrappers_mod.parseNamedArgs(ArgsStructType, class_infos, args, kwargs) orelse return null;
+
+                    const wrapped_args = ArgsWrapperType{ .value = result_args };
+                    const raw_result = @call(.auto, method, .{ self.getData(), wrapped_args });
+                    const result = unwrapSignatureValue(RawReturnType, raw_result);
+
+                    return handleReturn(result, self_obj.?, self.getData());
+                }
+
+                fn handleReturn(result: ReturnType, self_obj: *py.PyObject, self_data: *T) ?*py.PyObject {
+                    const rt_info = @typeInfo(ReturnType);
+                    const Conv = conversion.Converter(class_infos);
+
+                    if (rt_info == .pointer) {
+                        const ptr_info = rt_info.pointer;
+                        if (ptr_info.size == .one and ptr_info.child == T) {
+                            const result_ptr: *const T = if (ptr_info.is_const) result else result;
+                            if (result_ptr == self_data) {
+                                py.Py_IncRef(self_obj);
+                                return self_obj;
+                            }
+                        }
+                    }
+
+                    if (rt_info == .error_union) {
+                        if (result) |value| {
+                            const ValueType = @TypeOf(value);
+                            const val_info = @typeInfo(ValueType);
+                            if (val_info == .pointer and val_info.pointer.size == .one and val_info.pointer.child == T) {
+                                const result_ptr: *const T = if (val_info.pointer.is_const) value else value;
+                                if (result_ptr == self_data) {
+                                    py.Py_IncRef(self_obj);
+                                    return self_obj;
+                                }
+                            }
+
+                            return Conv.toPy(ValueType, value);
+                        } else |err| {
+                            if (py.PyErr_Occurred() == null) {
+                                const msg = @errorName(err);
+                                py.PyErr_SetString(errors_mod.mapWellKnownError(msg), msg.ptr);
+                            }
+
+                            return null;
+                        }
+                    } else if (rt_info == .optional) {
+                        if (result) |value| {
+                            return Conv.toPy(@TypeOf(value), value);
+                        } else {
+                            if (py.PyErr_Occurred() != null) return null;
+
                             return py.Py_RETURN_NONE();
                         }
                     } else if (ReturnType == void) {

--- a/src/lib/from.zig
+++ b/src/lib/from.zig
@@ -476,15 +476,19 @@ pub fn isStringConstType(comptime T: type) bool {
 // Calling Convention Detection
 // =============================================================================
 
-/// Check if a function takes pyoz.Args(T) as its first (and only) parameter.
+/// Check if a function takes pyoz.Args(T) as its last parameter.
 /// This means it uses named keyword arguments.
+/// Works for both module functions `fn(Args(T))` and methods `fn(*Self, Args(T))`.
 pub fn isNamedKwargsFunc(comptime Fn: type) bool {
     const info = @typeInfo(Fn);
     if (info != .@"fn") return false;
+
     const params = info.@"fn".params;
-    if (params.len != 1) return false;
-    const ParamType = params[0].type orelse return false;
+    if (params.len == 0) return false;
+
+    const ParamType = params[params.len - 1].type orelse return false;
     if (@typeInfo(ParamType) != .@"struct") return false;
+
     return @hasDecl(ParamType, "is_pyoz_args");
 }
 

--- a/src/lib/stubs.zig
+++ b/src/lib/stubs.zig
@@ -383,8 +383,13 @@ pub fn buildMlDoc(
                     need_comma = true;
                 }
 
-                if (params.len >= 1) {
-                    const ArgsWrapperType = params[0].type.?;
+                // Args param is last: index 0 for module funcs, 1 for methods
+                const args_param_idx: usize = switch (kind) {
+                    .instance_method, .class_method => 1,
+                    .module_func, .static_method => 0,
+                };
+                if (params.len > args_param_idx) {
+                    const ArgsWrapperType = params[args_param_idx].type.?;
                     if (@typeInfo(ArgsWrapperType) == .@"struct" and @hasDecl(ArgsWrapperType, "ArgsStruct")) {
                         const ArgsStructType = ArgsWrapperType.ArgsStruct;
                         const args_fields = @typeInfo(ArgsStructType).@"struct".fields;

--- a/src/lib/wrappers.zig
+++ b/src/lib/wrappers.zig
@@ -125,8 +125,86 @@ pub fn ArgsTuple(comptime params: anytype) type {
 /// Type for keyword function signature (C calling convention)
 pub const PyCFunctionWithKeywords = *const fn (?*PyObject, ?*PyObject, ?*PyObject) callconv(.c) ?*PyObject;
 
-/// Generate a Python-callable wrapper for a Zig function with named keyword arguments
-/// The function should take Args(SomeStruct) as its parameter
+/// Parse positional and keyword arguments into an Args struct.
+/// Sets the appropriate Python exception and returns null on failure.
+pub fn parseNamedArgs(
+    comptime ArgsStructType: type,
+    comptime class_infos: []const ClassInfo,
+    args: ?*py.PyObject,
+    kwargs: ?*py.PyObject,
+) ?ArgsStructType {
+    const Conv = Converter(class_infos);
+    const args_fields = @typeInfo(ArgsStructType).@"struct".fields;
+    var result: ArgsStructType = undefined;
+
+    // Get positional args count
+    const pos_count: usize = if (args) |a| @intCast(py.PyTuple_Size(a)) else 0;
+
+    // Parse each field
+    inline for (args_fields, 0..) |field, i| {
+        const has_default = field.default_value_ptr != null;
+        const is_optional = @typeInfo(field.type) == .optional;
+
+        // Try positional first
+        if (i < pos_count) {
+            const item = py.PyTuple_GetItem(args.?, @intCast(i)) orelse {
+                py.PyErr_SetString(py.PyExc_TypeError(), "Invalid argument at position " ++ std.fmt.comptimePrint("{}", .{i}));
+                return null;
+            };
+            if (is_optional and py.PyNone_Check(item)) {
+                @field(result, field.name) = null;
+            } else if (is_optional) {
+                @field(result, field.name) = Conv.fromPy(@typeInfo(field.type).optional.child, item) catch {
+                    py.PyErr_SetString(py.PyExc_TypeError(), "Invalid type for argument: " ++ field.name);
+                    return null;
+                };
+            } else {
+                @field(result, field.name) = Conv.fromPy(field.type, item) catch {
+                    py.PyErr_SetString(py.PyExc_TypeError(), "Invalid type for argument: " ++ field.name);
+                    return null;
+                };
+            }
+        } else if (kwargs) |kw| {
+            // Try keyword argument by name
+            if (py.PyDict_GetItemString(kw, field.name.ptr)) |item| {
+                if (is_optional and py.PyNone_Check(item)) {
+                    @field(result, field.name) = null;
+                } else if (is_optional) {
+                    @field(result, field.name) = Conv.fromPy(@typeInfo(field.type).optional.child, item) catch {
+                        py.PyErr_SetString(py.PyExc_TypeError(), "Invalid type for argument: " ++ field.name);
+                        return null;
+                    };
+                } else {
+                    @field(result, field.name) = Conv.fromPy(field.type, item) catch {
+                        py.PyErr_SetString(py.PyExc_TypeError(), "Invalid type for argument: " ++ field.name);
+                        return null;
+                    };
+                }
+            } else if (has_default) {
+                // Use default value
+                @field(result, field.name) = field.defaultValue().?;
+            } else if (is_optional) {
+                @field(result, field.name) = null;
+            } else {
+                py.PyErr_SetString(py.PyExc_TypeError(), "Missing required argument: " ++ field.name);
+                return null;
+            }
+        } else if (has_default) {
+            // Use default value
+            @field(result, field.name) = field.defaultValue().?;
+        } else if (is_optional) {
+            @field(result, field.name) = null;
+        } else {
+            py.PyErr_SetString(py.PyExc_TypeError(), "Missing required argument: " ++ field.name);
+            return null;
+        }
+    }
+
+    return result;
+}
+
+/// Generate a Python-callable wrapper for a Zig function with named keyword arguments.
+/// The function should take Args(SomeStruct) as its parameter.
 pub fn wrapFunctionWithNamedKeywords(comptime zig_func: anytype, comptime class_infos: []const ClassInfo) PyCFunctionWithKeywords {
     const Conv = Converter(class_infos);
     const Fn = @TypeOf(zig_func);
@@ -141,78 +219,12 @@ pub fn wrapFunctionWithNamedKeywords(comptime zig_func: anytype, comptime class_
     else
         @compileError("kwfunc parameter must be wrapped in pyoz.Args(T). Change `fn(" ++
             @typeName(ArgsWrapperType) ++ ")` to `fn(pyoz.Args(YourArgsStruct))`");
-    const args_fields = @typeInfo(ArgsStructType).@"struct".fields;
 
     return struct {
         fn wrapper(self: ?*PyObject, args: ?*PyObject, kwargs: ?*PyObject) callconv(.c) ?*PyObject {
             _ = self;
 
-            var result_args: ArgsStructType = undefined;
-
-            // Get positional args count
-            const pos_count: usize = if (args) |a| @intCast(py.PyTuple_Size(a)) else 0;
-
-            // Parse each field
-            inline for (args_fields, 0..) |field, i| {
-                const has_default = field.default_value_ptr != null;
-                const is_optional = @typeInfo(field.type) == .optional;
-
-                // Try positional first
-                if (i < pos_count) {
-                    const item = py.PyTuple_GetItem(args.?, @intCast(i)) orelse {
-                        setError(error.InvalidArgument);
-                        return null;
-                    };
-                    if (is_optional and py.PyNone_Check(item)) {
-                        @field(result_args, field.name) = null;
-                    } else if (is_optional) {
-                        const inner_type = @typeInfo(field.type).optional.child;
-                        @field(result_args, field.name) = Conv.fromPy(inner_type, item) catch {
-                            setFieldError(field.name);
-                            return null;
-                        };
-                    } else {
-                        @field(result_args, field.name) = Conv.fromPy(field.type, item) catch {
-                            setFieldError(field.name);
-                            return null;
-                        };
-                    }
-                } else if (kwargs) |kw| {
-                    // Try keyword argument by name
-                    if (py.PyDict_GetItemString(kw, field.name.ptr)) |item| {
-                        if (is_optional and py.PyNone_Check(item)) {
-                            @field(result_args, field.name) = null;
-                        } else if (is_optional) {
-                            const inner_type = @typeInfo(field.type).optional.child;
-                            @field(result_args, field.name) = Conv.fromPy(inner_type, item) catch {
-                                setFieldError(field.name);
-                                return null;
-                            };
-                        } else {
-                            @field(result_args, field.name) = Conv.fromPy(field.type, item) catch {
-                                setFieldError(field.name);
-                                return null;
-                            };
-                        }
-                    } else if (has_default) {
-                        // Use default value
-                        @field(result_args, field.name) = field.defaultValue().?;
-                    } else if (is_optional) {
-                        @field(result_args, field.name) = null;
-                    } else {
-                        setMissingError(field.name);
-                        return null;
-                    }
-                } else if (has_default) {
-                    // Use default value
-                    @field(result_args, field.name) = field.defaultValue().?;
-                } else if (is_optional) {
-                    @field(result_args, field.name) = null;
-                } else {
-                    setMissingError(field.name);
-                    return null;
-                }
-            }
+            const result_args = parseNamedArgs(ArgsStructType, class_infos, args, kwargs) orelse return null;
 
             // Call function with wrapped args
             const wrapped_args = ArgsWrapperType{ .value = result_args };
@@ -228,28 +240,18 @@ pub fn wrapFunctionWithNamedKeywords(comptime zig_func: anytype, comptime class_
                 if (result) |value| {
                     return Conv.toPy(@TypeOf(value), value);
                 } else |err| {
-                    setError(err);
+                    // Don't overwrite an exception already set by Python, e.g.
+                    // KeyboardInterrupt from checkSignals.
+                    if (py.PyErr_Occurred() == null) {
+                        const msg = @errorName(err);
+                        py.PyErr_SetString(mapErrorToExc(err), msg.ptr);
+                    }
+
                     return null;
                 }
             } else {
                 return Conv.toPy(RT, result);
             }
-        }
-
-        fn setError(err: anyerror) void {
-            // Don't overwrite an exception already set by Python
-            // (e.g., KeyboardInterrupt from checkSignals)
-            if (py.PyErr_Occurred() != null) return;
-            const msg = @errorName(err);
-            py.PyErr_SetString(mapErrorToExc(err), msg.ptr);
-        }
-
-        fn setFieldError(comptime field_name: []const u8) void {
-            py.PyErr_SetString(py.PyExc_TypeError(), "Invalid type for argument: " ++ field_name);
-        }
-
-        fn setMissingError(comptime field_name: []const u8) void {
-            py.PyErr_SetString(py.PyExc_TypeError(), "Missing required argument: " ++ field_name);
         }
     }.wrapper;
 }

--- a/src/lib/wrappers.zig
+++ b/src/lib/wrappers.zig
@@ -140,6 +140,18 @@ pub fn parseNamedArgs(
     // Get positional args count
     const pos_count: usize = if (args) |a| @intCast(py.PyTuple_Size(a)) else 0;
 
+    if (pos_count > args_fields.len) {
+        py.PyErr_SetString(
+            py.PyExc_TypeError(),
+            "Too many positional arguments (expected at most " ++
+                std.fmt.comptimePrint("{}", .{args_fields.len}) ++ ")",
+        );
+        return null;
+    }
+
+    // Track how many kwargs were consumed to detect unexpected kwargs.
+    var kwargs_consumed: usize = 0;
+
     // Parse each field
     inline for (args_fields, 0..) |field, i| {
         const has_default = field.default_value_ptr != null;
@@ -155,28 +167,33 @@ pub fn parseNamedArgs(
                 @field(result, field.name) = null;
             } else if (is_optional) {
                 @field(result, field.name) = Conv.fromPy(@typeInfo(field.type).optional.child, item) catch {
-                    py.PyErr_SetString(py.PyExc_TypeError(), "Invalid type for argument: " ++ field.name);
+                    if (py.PyErr_Occurred() == null)
+                        py.PyErr_SetString(py.PyExc_TypeError(), "Invalid type for argument: " ++ field.name);
                     return null;
                 };
             } else {
                 @field(result, field.name) = Conv.fromPy(field.type, item) catch {
-                    py.PyErr_SetString(py.PyExc_TypeError(), "Invalid type for argument: " ++ field.name);
+                    if (py.PyErr_Occurred() == null)
+                        py.PyErr_SetString(py.PyExc_TypeError(), "Invalid type for argument: " ++ field.name);
                     return null;
                 };
             }
         } else if (kwargs) |kw| {
             // Try keyword argument by name
             if (py.PyDict_GetItemString(kw, field.name.ptr)) |item| {
+                kwargs_consumed += 1;
                 if (is_optional and py.PyNone_Check(item)) {
                     @field(result, field.name) = null;
                 } else if (is_optional) {
                     @field(result, field.name) = Conv.fromPy(@typeInfo(field.type).optional.child, item) catch {
-                        py.PyErr_SetString(py.PyExc_TypeError(), "Invalid type for argument: " ++ field.name);
+                        if (py.PyErr_Occurred() == null)
+                            py.PyErr_SetString(py.PyExc_TypeError(), "Invalid type for argument: " ++ field.name);
                         return null;
                     };
                 } else {
                     @field(result, field.name) = Conv.fromPy(field.type, item) catch {
-                        py.PyErr_SetString(py.PyExc_TypeError(), "Invalid type for argument: " ++ field.name);
+                        if (py.PyErr_Occurred() == null)
+                            py.PyErr_SetString(py.PyExc_TypeError(), "Invalid type for argument: " ++ field.name);
                         return null;
                     };
                 }
@@ -196,6 +213,25 @@ pub fn parseNamedArgs(
             @field(result, field.name) = null;
         } else {
             py.PyErr_SetString(py.PyExc_TypeError(), "Missing required argument: " ++ field.name);
+            return null;
+        }
+    }
+
+    if (kwargs) |kw| {
+        // Check for unexpected keyword arguments.
+        const kwargs_total: usize = @intCast(py.PyDict_Size(kw));
+        if (kwargs_consumed < kwargs_total) {
+            // Distinguish between duplicate positional+keyword and truly unexpected kwargs.
+            inline for (args_fields, 0..) |field, i| {
+                if (i < pos_count and py.PyDict_GetItemString(kw, field.name.ptr) != null) {
+                    py.PyErr_SetString(
+                        py.PyExc_TypeError(),
+                        "Got multiple values for argument '" ++ field.name ++ "'",
+                    );
+                    return null;
+                }
+            }
+            py.PyErr_SetString(py.PyExc_TypeError(), "Unexpected keyword argument");
             return null;
         }
     }

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -804,6 +804,40 @@ test "Point - docstrings" {
     try std.testing.expect(try python.eval(bool, "'2D point' in example.Point.__doc__"));
 }
 
+test "Point - translate with keyword arguments" {
+    const python = try initTestPython();
+
+    // Both keyword args
+    try python.exec("p = example.Point(1.0, 2.0)");
+    try python.exec("p.translate(dx=3.0, dy=4.0)");
+    try std.testing.expectApproxEqAbs(@as(f64, 4.0), try python.eval(f64, "p.x"), 0.0001);
+    try std.testing.expectApproxEqAbs(@as(f64, 6.0), try python.eval(f64, "p.y"), 0.0001);
+
+    // Positional args
+    try python.exec("p2 = example.Point(0.0, 0.0)");
+    try python.exec("p2.translate(1.0, 2.0)");
+    try std.testing.expectApproxEqAbs(@as(f64, 1.0), try python.eval(f64, "p2.x"), 0.0001);
+    try std.testing.expectApproxEqAbs(@as(f64, 2.0), try python.eval(f64, "p2.y"), 0.0001);
+
+    // Partial keyword (dx only, dy defaults to 0)
+    try python.exec("p3 = example.Point(5.0, 5.0)");
+    try python.exec("p3.translate(dx=10.0)");
+    try std.testing.expectApproxEqAbs(@as(f64, 15.0), try python.eval(f64, "p3.x"), 0.0001);
+    try std.testing.expectApproxEqAbs(@as(f64, 5.0), try python.eval(f64, "p3.y"), 0.0001);
+
+    // No args (both default to 0)
+    try python.exec("p4 = example.Point(1.0, 1.0)");
+    try python.exec("p4.translate()");
+    try std.testing.expectApproxEqAbs(@as(f64, 1.0), try python.eval(f64, "p4.x"), 0.0001);
+    try std.testing.expectApproxEqAbs(@as(f64, 1.0), try python.eval(f64, "p4.y"), 0.0001);
+
+    // Mixed positional + keyword
+    try python.exec("p5 = example.Point(0.0, 0.0)");
+    try python.exec("p5.translate(5.0, dy=3.0)");
+    try std.testing.expectApproxEqAbs(@as(f64, 5.0), try python.eval(f64, "p5.x"), 0.0001);
+    try std.testing.expectApproxEqAbs(@as(f64, 3.0), try python.eval(f64, "p5.y"), 0.0001);
+}
+
 // ============================================================================
 // CLASS: Number (arithmetic operations)
 // ============================================================================

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -1959,6 +1959,60 @@ test "fn calculate_named - keyword arguments with operations" {
     try std.testing.expectApproxEqAbs(@as(f64, 2.5), try python.eval(f64, "example.calculate_named(x=10, y=4, operation='div')"), 0.0001);
 }
 
+test "fn greet_named - fromPy exception not overwritten" {
+    const python = try initTestPython();
+
+    try python.exec(
+        \\try:
+        \\    example.greet_named(name='hi', times=2**63)
+        \\    exc_type = None
+        \\except OverflowError:
+        \\    exc_type = 'OverflowError'
+        \\except TypeError:
+        \\    exc_type = 'TypeError'
+    );
+    try std.testing.expect(try python.eval(bool, "exc_type == 'OverflowError'"));
+}
+
+test "fn greet_named - unexpected kwargs rejected" {
+    const python = try initTestPython();
+
+    try python.exec(
+        \\try:
+        \\    example.greet_named(name='hi', foo=1)
+        \\    raised = False
+        \\except TypeError:
+        \\    raised = True
+    );
+    try std.testing.expect(try python.eval(bool, "raised"));
+}
+
+test "fn greet_named - too many positional args rejected" {
+    const python = try initTestPython();
+
+    try python.exec(
+        \\try:
+        \\    example.greet_named('hi', 'Hey', 1, True, 'extra')
+        \\    raised = False
+        \\except TypeError:
+        \\    raised = True
+    );
+    try std.testing.expect(try python.eval(bool, "raised"));
+}
+
+test "fn greet_named - duplicate positional and keyword rejected" {
+    const python = try initTestPython();
+
+    try python.exec(
+        \\try:
+        \\    example.greet_named('hi', name='hello')
+        \\    raised = False
+        \\except TypeError:
+        \\    raised = True
+    );
+    try std.testing.expect(try python.eval(bool, "raised"));
+}
+
 // ============================================================================
 // SUBMODULES (math submodule)
 // ============================================================================


### PR DESCRIPTION
Thank you for developing PyOZ! Please consider adding `pyoz.Args()` support to classes.

```zig
const Point = struct {
    x: f64,
    y: f64,

    pub fn translate(self: *Point, args: pyoz.Args(struct {
        dx: f64 = 0,
        dy: f64 = 0,
    })) void {
        self.x += args.value.dx;
        self.y += args.value.dy;
    }
};
```